### PR TITLE
Console and RTC Alarm Bring-up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ dkms.conf
 
 # Misc
 *.pdf-view-restore
+*.#*
+build/
+linkermap.html

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ CFLAGS += -fomit-frame-pointer # do not use fp if not needed
 CFLAGS += -ffunction-sections -fdata-sections
 CFLAGS += -fstack-usage
 CFLAGS += -fcallgraph-info
-CFLAGS += -Wstack-usage=75
+CFLAGS += -Wstack-usage=64
 CFLAGS += -g3
 CFLAGS += --specs=nosys.specs
 CFLAGS += -g

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ OBJDIRS := $(patsubst %, $(BUILD_DIR)/%, $(CSOURCES))
 ASMOBJDIRS := $(patsubst %, $(BUILD_DIR)/%, $(ASMSOURCES))
 
 CFLAGS += -mcpu=cortex-m0plus -mthumb
-CFLAGS += -O1 # optimization off
+CFLAGS += -O0 # optimization off
 CFLAGS += -std=gnu11 # use GNU 11 standard
 CFLAGS += -mfloat-abi=soft # SOFT FPU
 CFLAGS += -fno-common

--- a/Makefile
+++ b/Makefile
@@ -5,14 +5,18 @@ INCLUDES = \
 -Isubmodules/FreeRTOS-Kernel/include \
 -Isubmodules/FreeRTOS-Kernel/portable/GCC/ARM_CM0 \
 -Isubmodules/hal/include \
+-Isubmodules/hal/include/dev \
 -Iinclude \
--Isrc/hal
+-Isrc/hal \
+-Isrc/dev
 
 CSOURCES = $(wildcard *.c)
 CSOURCES += $(wildcard src/*.c)
 CSOURCES += $(wildcard src/hal/*.c)
+CSOURCES += $(wildcard src/dev/*.c)
 CSOURCES += $(wildcard micro_specific/*.c)
 CSOURCES += $(wildcard submodules/hal/src/*.c)
+CSOURCES += $(wildcard submodules/hal/src/dev/*.c)
 CSOURCES += $(wildcard submodules/FreeRTOS-Kernel/*.c)
 CSOURCES += $(wildcard submodules/FreeRTOS-Kernel/portable/GCC/ARM_CM0/*.c)
 CSOURCES += submodules/FreeRTOS-Kernel/portable/MemMang/heap_4.c
@@ -28,7 +32,7 @@ OBJDIRS := $(patsubst %, $(BUILD_DIR)/%, $(CSOURCES))
 ASMOBJDIRS := $(patsubst %, $(BUILD_DIR)/%, $(ASMSOURCES))
 
 CFLAGS += -mcpu=cortex-m0plus -mthumb
-CFLAGS += -O0 # optimization off
+CFLAGS += -O1 # optimization off
 CFLAGS += -std=gnu11 # use GNU 11 standard
 CFLAGS += -mfloat-abi=soft # SOFT FPU
 CFLAGS += -fno-common
@@ -41,13 +45,16 @@ CFLAGS += -fsingle-precision-constant
 CFLAGS += -fomit-frame-pointer # do not use fp if not needed
 CFLAGS += -ffunction-sections -fdata-sections
 CFLAGS += -fstack-usage
+CFLAGS += -fcallgraph-info
+CFLAGS += -Wstack-usage=75
 CFLAGS += -g3
 CFLAGS += --specs=nosys.specs
 CFLAGS += -g
 CFLAGS += $(INCLUDES)
 
 
-LDFLAGS += -Wl,--gc-sections
+LDFLAGS += -Wl,--gc-sections,--print-memory-usage
+LDFLAGS += -Wl,-Map=$(BUILD_DIR)/firmware.map
 LDFLAGS += -mcpu=cortex-m0plus -mthumb
 LDFLAGS += -mfloat-abi=soft # SOFT FPU
 LDFLAGS += -T micro_specific/STM32L031K6TX_FLASH.ld
@@ -94,4 +101,7 @@ debug: $(BUILD_DIR)/firmware.elf
 	@gdb \
 		--symbols=$(BUILD_DIR)/firmware.elf \
 		-ex 'target extended-remote localhost:4242'
+
+linkermapviz: $(BUILD_DIR)/firmware.map
+	@linkermapviz < $(BUILD_DIR)/firmware.map
 

--- a/compile_flags.txt
+++ b/compile_flags.txt
@@ -2,6 +2,8 @@
 -ICMSIS/Include
 -Isubmodules/FreeRTOS-Kernel/include
 -Isubmodules/FreeRTOS-Kernel/portable/GCC/ARM_CM0
+-Isubmodules/hal/include/dev
 -Isubmodules/hal/include
 -Isrc/hal
+-Isrc/dev
 -Iinclude

--- a/include/FreeRTOSConfig.h
+++ b/include/FreeRTOSConfig.h
@@ -57,17 +57,17 @@
 #define configENABLE_MPU                         0
 
 #define configUSE_PREEMPTION                     1
-#define configSUPPORT_STATIC_ALLOCATION          1
+#define configSUPPORT_STATIC_ALLOCATION          0
 #define configSUPPORT_DYNAMIC_ALLOCATION         1
 #define configUSE_IDLE_HOOK                      0
 #define configUSE_TICK_HOOK                      0
 #define configCPU_CLOCK_HZ                       ( SystemCoreClock )
 #define configTICK_RATE_HZ                       ((TickType_t)1000)
-#define configMAX_PRIORITIES                     ( 56 )
+#define configMAX_PRIORITIES                     ( 5 )
 #define configMINIMAL_STACK_SIZE                 ((uint16_t)128)
 #define configTOTAL_HEAP_SIZE                    ((size_t)3072)
 #define configMAX_TASK_NAME_LEN                  ( 16 )
-#define configUSE_TRACE_FACILITY                 1
+#define configUSE_TRACE_FACILITY                 0
 #define configUSE_16_BIT_TICKS                   0
 #define configUSE_MUTEXES                        1
 #define configQUEUE_REGISTRY_SIZE                8
@@ -98,7 +98,7 @@ to exclude the API function. */
 #define INCLUDE_vTaskCleanUpResources        0
 #define INCLUDE_vTaskSuspend                 1
 #define INCLUDE_vTaskDelayUntil              1
-#define INCLUDE_vTaskDelay                   1
+#define INCLUDE_vTaskDelay                   0
 #define INCLUDE_xTaskGetSchedulerState       1
 #define INCLUDE_xTimerPendFunctionCall       1
 #define INCLUDE_xQueueGetMutexHolder         1

--- a/include/FreeRTOSConfig.h
+++ b/include/FreeRTOSConfig.h
@@ -64,8 +64,8 @@
 #define configCPU_CLOCK_HZ                       ( SystemCoreClock )
 #define configTICK_RATE_HZ                       ((TickType_t)1000)
 #define configMAX_PRIORITIES                     ( 5 )
-#define configMINIMAL_STACK_SIZE                 ((uint16_t)128)
-#define configTOTAL_HEAP_SIZE                    ((size_t)3072)
+#define configMINIMAL_STACK_SIZE                 ((uint16_t)64)
+#define configTOTAL_HEAP_SIZE                    ((size_t)4096)
 #define configMAX_TASK_NAME_LEN                  ( 16 )
 #define configUSE_TRACE_FACILITY                 0
 #define configUSE_16_BIT_TICKS                   0

--- a/include/interrupts.h
+++ b/include/interrupts.h
@@ -8,6 +8,11 @@
 extern "C" {
 #endif
 
+// Shared Initialization
+// Includes NVIC registration and priority setting
+void interrupts_init(void);
+
+// Define IRQ Handlers as specified in the startup assembly
 void USART2_IRQHandler(void);
 
 #ifdef __cplusplus

--- a/micro_specific/STM32L031K6TX_FLASH.ld
+++ b/micro_specific/STM32L031K6TX_FLASH.ld
@@ -38,8 +38,8 @@ ENTRY(Reset_Handler)
 /* Highest address of the user mode stack */
 _estack = ORIGIN(RAM) + LENGTH(RAM); /* end of "RAM" Ram type memory */
 
-_Min_Heap_Size = 0x200; /* required amount of heap */
-_Min_Stack_Size = 0x400; /* required amount of stack */
+_Min_Heap_Size = 0x100; /* required amount of heap */
+_Min_Stack_Size = 0x200; /* required amount of stack */
 
 /* Memories definition */
 MEMORY

--- a/micro_specific/interrupts.c
+++ b/micro_specific/interrupts.c
@@ -1,0 +1,21 @@
+// File to place interrupt handler implementation for this micro
+// Names of each handler are found in the assembly startup code
+
+// Standard Library Imports
+
+// IO layer imports
+#include "hal.h"
+#include "hal_uart.h"
+
+// Device Layer Imports
+#include "dev_console.h"
+
+/* void USART2_IRQHandler(void) { */
+/*   // This ISR handler belongs to the COM_PORT / console UART. */
+/*   // Right now only the receive interrupt is enabled. */
+/*   char receivedChar; */
+/*   hal_uart_receiveChar(HAL_UART_CHANNEL_COM_PORT, &receivedChar); */
+
+/*   // Feed the character into the console application */
+/*   dev_console_collectCharFromISR(receivedChar); */
+/* } */

--- a/micro_specific/interrupts.c
+++ b/micro_specific/interrupts.c
@@ -2,20 +2,67 @@
 // Names of each handler are found in the assembly startup code
 
 // Standard Library Imports
+#include <string.h>
 
 // IO layer imports
+#include "FreeRTOS.h"
+#include "projdefs.h"
+#include "queue.h"
+#include "task.h"
+#include "semphr.h"
+
+#include "stm32l0xx.h"
+#include "system_stm32l0xx.h"
+
 #include "hal.h"
 #include "hal_uart.h"
 
 // Device Layer Imports
 #include "dev_console.h"
 
-/* void USART2_IRQHandler(void) { */
-/*   // This ISR handler belongs to the COM_PORT / console UART. */
-/*   // Right now only the receive interrupt is enabled. */
-/*   char receivedChar; */
-/*   hal_uart_receiveChar(HAL_UART_CHANNEL_COM_PORT, &receivedChar); */
+extern xTaskHandle consoleTaskHandle;
 
-/*   // Feed the character into the console application */
-/*   dev_console_collectCharFromISR(receivedChar); */
-/* } */
+volatile char receivedString[DEV_CONSOLE_MAX_COMMAND_LENGTH] = {0};
+volatile uint32_t receivedCharCount = 0;
+volatile bool receivedStringReady = false;
+
+void interrupts_init() {
+  // ENABLE USART2 Interrupt in the NVIC
+  // Use lowest priority, might need to tinker with this later
+  NVIC_SetPriority(USART2_IRQn, 0x03);
+  NVIC_EnableIRQ(USART2_IRQn);
+}
+
+void USART2_IRQHandler(void) {
+  // This ISR handler belongs to the COM_PORT / console UART.
+  // Right now only the receive interrupt is enabled.
+
+  // Clear the interrupt by reading the character
+  char receivedChar;
+  hal_uart_receiveChar(HAL_UART_CHANNEL_COM_PORT, &receivedChar);
+
+  if (receivedStringReady) {
+    // If the console task has not processed the previous command, discard the character
+    return;
+  }
+
+  if (receivedCharCount < DEV_CONSOLE_MAX_COMMAND_LENGTH - 1) {
+    // Put the char in the buffer
+    receivedString[receivedCharCount] = receivedChar;
+    receivedCharCount++;
+
+    // If the received character is a new line, we know we have a complete
+    // command and notify the console task.
+    if (receivedChar == '\n') {
+      // Indicate that the string is ready and then notify the console task
+      receivedStringReady = true;
+      vTaskNotifyGiveFromISR(consoleTaskHandle, NULL);
+      receivedCharCount = 0;
+    }
+  } else {
+    // If the buffer is full and we never received a newline then clear it
+    memset((char *)receivedString, 0U, sizeof(receivedString));
+    receivedCharCount = 0;
+  }
+
+}

--- a/src/dev/dev_alarm_microSpecific.c
+++ b/src/dev/dev_alarm_microSpecific.c
@@ -1,0 +1,39 @@
+#include <string.h>
+#include "hal.h"
+
+#include "dev_alarm.h"
+#include "dev_alarm_microSpecific.h"
+
+// alarm channel definitions
+static const dev_alarm_channelConfig_S dev_alarm_channelConfigs[DEV_ALARM_CHANNEL_COUNT] = {
+  [DEV_ALARM_CHANNEL_PRIMARY] = {
+    .alarmTime = {
+      // 7:30 AM Alarm from Monday to Friday
+      .hour = 7,
+      .minute = 30,
+      .weekdayMask = 0x1F
+    },
+    .callback = NULL,
+  },
+
+  [DEV_ALARM_CHANNEL_SECONDARY] = {
+    .alarmTime = {
+      // 9:30 AM Alarm on Saturday and Sunday
+      .hour = 9,
+      .minute = 30,
+      .weekdayMask = 0x60
+    },
+    .callback = NULL,
+  },
+
+};
+
+static const dev_alarm_config_S dev_alarm_config = {
+  .channels = dev_alarm_channelConfigs
+};
+
+void dev_alarm_microSpecific_init(void) {
+  // Initialize shared module
+  dev_alarm_init(&dev_alarm_config);
+}
+

--- a/src/dev/dev_alarm_microSpecific.h
+++ b/src/dev/dev_alarm_microSpecific.h
@@ -1,0 +1,25 @@
+#ifndef DEV_ALARM_MICRO_SPECIFIC_H
+#define DEV_ALARM_MICRO_SPECIFIC_H
+
+#include "hal.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// For now support just two alarms. (weekend and weekday) In future, we could
+// make this dynamically allocated to add remove them through the console or
+// other interface.
+typedef enum {
+  DEV_ALARM_CHANNEL_PRIMARY,
+  DEV_ALARM_CHANNEL_SECONDARY,
+  DEV_ALARM_CHANNEL_COUNT,
+  DEV_ALARM_CHANNEL_UNKNOWN
+} dev_alarm_channel_E;
+
+void dev_alarm_microSpecific_init(void);
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif /* DEV_ALARM_MICRO_SPECIFIC_H */

--- a/src/dev/dev_console_microSpecific.c
+++ b/src/dev/dev_console_microSpecific.c
@@ -1,12 +1,15 @@
 #include "hal.h"
 
+#include "hal_rtc.h"
+#include "hal_rtc_microSpecific.h"
+
 #include "hal_uart.h"
 #include "hal_uart_microSpecific.h"
 
 #include "dev_console.h"
 #include "dev_console_microSpecific.h"
 
-static hal_error_E dev_console_command_rtc(char **arg, uint8_t args);
+static hal_error_E dev_console_command_rtc(char **arg, uint32_t args);
 
 // Commands and callbacks
 static const dev_console_command_S dev_console_commands[] = {
@@ -26,7 +29,44 @@ hal_error_E dev_console_microSpecific_init(void) {
   return dev_console_init(&dev_console_config);
 }
 
-static hal_error_E dev_console_command_rtc(char **arg, uint8_t args) {
+static hal_error_E dev_console_command_rtc(char **arg, uint32_t args) {
+  hal_rtc_time_S currentTime;
+  (void)hal_rtc_getTime(&currentTime);
+  char secondsTens = (char)((currentTime.seconds / 10) % 10) + '0';
+  char secondsUnits = (char)(currentTime.seconds % 10) + '0';
+  char minutesTens = (char)((currentTime.minute / 10) % 10) + '0';
+  char minutesUnits = (char)(currentTime.minute % 10) + '0';
+  char hoursTens = (char)((currentTime.hour / 10) % 10) + '0';
+  char hoursUnits = (char)(currentTime.hour % 10) + '0';
+  char dayTens = (char)((currentTime.day / 10) % 10) + '0';
+  char dayUnits = (char)(currentTime.day % 10) + '0';
+  char monthTens = (char)((currentTime.month / 10) % 10) + '0';
+  char monthUnits = (char)(currentTime.month % 10) + '0';
+  char yearTens = (char)((currentTime.year / 10) % 10) + '0';
+  char yearUnits = (char)(currentTime.year % 10) + '0';
+  (void)hal_uart_sendChar(HAL_UART_CHANNEL_COM_PORT, '2');
+  (void)hal_uart_sendChar(HAL_UART_CHANNEL_COM_PORT, '0');
+  (void)hal_uart_sendChar(HAL_UART_CHANNEL_COM_PORT, yearTens);
+  (void)hal_uart_sendChar(HAL_UART_CHANNEL_COM_PORT, yearUnits);
+  (void)hal_uart_sendChar(HAL_UART_CHANNEL_COM_PORT, '/');
+  (void)hal_uart_sendChar(HAL_UART_CHANNEL_COM_PORT, monthTens);
+  (void)hal_uart_sendChar(HAL_UART_CHANNEL_COM_PORT, monthUnits);
+  (void)hal_uart_sendChar(HAL_UART_CHANNEL_COM_PORT, '/');
+  (void)hal_uart_sendChar(HAL_UART_CHANNEL_COM_PORT, dayTens);
+  (void)hal_uart_sendChar(HAL_UART_CHANNEL_COM_PORT, dayUnits);
+
+  (void)hal_uart_sendChar(HAL_UART_CHANNEL_COM_PORT, '-');
+
+  (void)hal_uart_sendChar(HAL_UART_CHANNEL_COM_PORT, hoursTens);
+  (void)hal_uart_sendChar(HAL_UART_CHANNEL_COM_PORT, hoursUnits);
+  (void)hal_uart_sendChar(HAL_UART_CHANNEL_COM_PORT, ':');
+  (void)hal_uart_sendChar(HAL_UART_CHANNEL_COM_PORT, minutesTens);
+  (void)hal_uart_sendChar(HAL_UART_CHANNEL_COM_PORT, minutesUnits);
+  (void)hal_uart_sendChar(HAL_UART_CHANNEL_COM_PORT, ':');
+  (void)hal_uart_sendChar(HAL_UART_CHANNEL_COM_PORT, secondsTens);
+  (void)hal_uart_sendChar(HAL_UART_CHANNEL_COM_PORT, secondsUnits);
+  (void)hal_uart_sendChar(HAL_UART_CHANNEL_COM_PORT, '\n');
+
   return HAL_ERROR_OK;
 }
 

--- a/src/dev/dev_console_microSpecific.c
+++ b/src/dev/dev_console_microSpecific.c
@@ -1,0 +1,32 @@
+#include "hal.h"
+
+#include "hal_uart.h"
+#include "hal_uart_microSpecific.h"
+
+#include "dev_console.h"
+#include "dev_console_microSpecific.h"
+
+static hal_error_E dev_console_command_rtc(char **arg, uint8_t args);
+
+// Commands and callbacks
+static const dev_console_command_S dev_console_commands[] = {
+  {
+    .prefix = "rtc",
+    .callback = dev_console_command_rtc
+  }
+};
+
+static const dev_console_config_S dev_console_config = {
+  .consolePort = HAL_UART_CHANNEL_COM_PORT,
+  .commands = dev_console_commands,
+  .commandCount = sizeof(dev_console_commands)
+};
+
+hal_error_E dev_console_microSpecific_init(void) {
+  return dev_console_init(&dev_console_config);
+}
+
+static hal_error_E dev_console_command_rtc(char **arg, uint8_t args) {
+  return HAL_ERROR_OK;
+}
+

--- a/src/dev/dev_console_microSpecific.h
+++ b/src/dev/dev_console_microSpecific.h
@@ -1,0 +1,15 @@
+#ifndef DEV_CONSOLE_MICRO_SPECIFIC_H
+#define DEV_CONSOLE_MICRO_SPECIFIC_H
+
+#include "hal.h"
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+hal_error_E dev_console_microSpecific_init(void);
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif /* DEV_CONSOLE_MICRO_SPECIFIC_H */

--- a/src/hal/hal_rtc_microSpecific.c
+++ b/src/hal/hal_rtc_microSpecific.c
@@ -1,4 +1,5 @@
 #include <stdbool.h>
+#include <stdint.h>
 #include <string.h>
 
 #include "stm32l031xx.h"
@@ -134,6 +135,9 @@ static hal_error_E hal_rtc_microSpecific_private_getTimestamp(hal_rtc_time_S *ti
     uint8_t hoursTens = (uint8_t)((rawTimeRegister & RTC_TR_HT_Msk) >> RTC_TR_HT_Pos) * 10;
     uint8_t hoursUnits = (uint8_t)((rawTimeRegister & RTC_TR_HU_Msk) >> RTC_TR_HU_Pos);
     time->hour = hoursTens + hoursUnits;
+
+    uint8_t weekdayUnits = (uint8_t)((rawDateRegister & RTC_DR_WDU_Msk) >> RTC_DR_WDU_Pos);
+    time->weekday = weekdayUnits;
 
     uint8_t dayTens = (uint8_t)((rawDateRegister & RTC_DR_DT_Msk) >> RTC_DR_DT_Pos) * 10;
     uint8_t dayUnits = (uint8_t)((rawDateRegister & RTC_DR_DU_Msk) >> RTC_DR_DU_Pos);

--- a/src/hal/hal_uart_microSpecific.c
+++ b/src/hal/hal_uart_microSpecific.c
@@ -21,7 +21,7 @@ static const hal_uart_channelConfig_S hal_uart_channelConfigs[HAL_UART_CHANNEL_C
 };
 
 // Config
-static hal_uart_config_S hal_uart_config = {
+static const hal_uart_config_S hal_uart_config = {
   .channels     = hal_uart_channelConfigs,
   .channelCount = HAL_UART_CHANNEL_COUNT,
 };

--- a/src/main.c
+++ b/src/main.c
@@ -1,6 +1,5 @@
 #include <stdint.h>
 
-#include "stm32l031xx.h"
 #include "stm32l0xx.h"
 
 #include "system_stm32l0xx.h"
@@ -18,6 +17,9 @@
 
 #include "hal_rtc.h"
 #include "hal_rtc_microSpecific.h"
+
+#include "dev_console.h"
+#include "dev_console_microSpecific.h"
 
 #include "interrupts.h"
 
@@ -47,93 +49,93 @@ static void blinky_task(void *pvParameters) {
   }
 }
 
-static void rtc_task(void *pvParameters) {
-  TickType_t lastWakeTime = xTaskGetTickCount();
-  const TickType_t freq = 1000;
+/* static void rtc_task(void *pvParameters) { */
+/*   TickType_t lastWakeTime = xTaskGetTickCount(); */
+/*   const TickType_t freq = 1000; */
 
-  for (;;) {
-    // Transfer the byte if the peripheral is available
-    hal_rtc_time_S currentTime;
-    currentTime.seconds = 0;
-    (void)hal_rtc_getTime(&currentTime);
-    char secondsTens = (char)((currentTime.seconds / 10) % 10) + '0';
-    char secondsUnits = (char)(currentTime.seconds % 10) + '0';
-    char minutesTens = (char)((currentTime.minute / 10) % 10) + '0';
-    char minutesUnits = (char)(currentTime.minute % 10) + '0';
-    char hoursTens = (char)((currentTime.hour / 10) % 10) + '0';
-    char hoursUnits = (char)(currentTime.hour % 10) + '0';
-    char dayTens = (char)((currentTime.day / 10) % 10) + '0';
-    char dayUnits = (char)(currentTime.day % 10) + '0';
-    char monthTens = (char)((currentTime.month / 10) % 10) + '0';
-    char monthUnits = (char)(currentTime.month % 10) + '0';
-    char yearTens = (char)((currentTime.year / 10) % 10) + '0';
-    char yearUnits = (char)(currentTime.year % 10) + '0';
-    (void)hal_uart_sendChar(HAL_UART_CHANNEL_COM_PORT, '2');
-    (void)hal_uart_sendChar(HAL_UART_CHANNEL_COM_PORT, '0');
-    (void)hal_uart_sendChar(HAL_UART_CHANNEL_COM_PORT, yearTens);
-    (void)hal_uart_sendChar(HAL_UART_CHANNEL_COM_PORT, yearUnits);
-    (void)hal_uart_sendChar(HAL_UART_CHANNEL_COM_PORT, '/');
-    (void)hal_uart_sendChar(HAL_UART_CHANNEL_COM_PORT, monthTens);
-    (void)hal_uart_sendChar(HAL_UART_CHANNEL_COM_PORT, monthUnits);
-    (void)hal_uart_sendChar(HAL_UART_CHANNEL_COM_PORT, '/');
-    (void)hal_uart_sendChar(HAL_UART_CHANNEL_COM_PORT, dayTens);
-    (void)hal_uart_sendChar(HAL_UART_CHANNEL_COM_PORT, dayUnits);
+/*   for (;;) { */
+/*     // Transfer the byte if the peripheral is available */
+/*     hal_rtc_time_S currentTime; */
+/*     currentTime.seconds = 0; */
+/*     (void)hal_rtc_getTime(&currentTime); */
+/*     char secondsTens = (char)((currentTime.seconds / 10) % 10) + '0'; */
+/*     char secondsUnits = (char)(currentTime.seconds % 10) + '0'; */
+/*     char minutesTens = (char)((currentTime.minute / 10) % 10) + '0'; */
+/*     char minutesUnits = (char)(currentTime.minute % 10) + '0'; */
+/*     char hoursTens = (char)((currentTime.hour / 10) % 10) + '0'; */
+/*     char hoursUnits = (char)(currentTime.hour % 10) + '0'; */
+/*     char dayTens = (char)((currentTime.day / 10) % 10) + '0'; */
+/*     char dayUnits = (char)(currentTime.day % 10) + '0'; */
+/*     char monthTens = (char)((currentTime.month / 10) % 10) + '0'; */
+/*     char monthUnits = (char)(currentTime.month % 10) + '0'; */
+/*     char yearTens = (char)((currentTime.year / 10) % 10) + '0'; */
+/*     char yearUnits = (char)(currentTime.year % 10) + '0'; */
+/*     (void)hal_uart_sendChar(HAL_UART_CHANNEL_COM_PORT, '2'); */
+/*     (void)hal_uart_sendChar(HAL_UART_CHANNEL_COM_PORT, '0'); */
+/*     (void)hal_uart_sendChar(HAL_UART_CHANNEL_COM_PORT, yearTens); */
+/*     (void)hal_uart_sendChar(HAL_UART_CHANNEL_COM_PORT, yearUnits); */
+/*     (void)hal_uart_sendChar(HAL_UART_CHANNEL_COM_PORT, '/'); */
+/*     (void)hal_uart_sendChar(HAL_UART_CHANNEL_COM_PORT, monthTens); */
+/*     (void)hal_uart_sendChar(HAL_UART_CHANNEL_COM_PORT, monthUnits); */
+/*     (void)hal_uart_sendChar(HAL_UART_CHANNEL_COM_PORT, '/'); */
+/*     (void)hal_uart_sendChar(HAL_UART_CHANNEL_COM_PORT, dayTens); */
+/*     (void)hal_uart_sendChar(HAL_UART_CHANNEL_COM_PORT, dayUnits); */
 
-    (void)hal_uart_sendChar(HAL_UART_CHANNEL_COM_PORT, '-');
+/*     (void)hal_uart_sendChar(HAL_UART_CHANNEL_COM_PORT, '-'); */
 
-    (void)hal_uart_sendChar(HAL_UART_CHANNEL_COM_PORT, hoursTens);
-    (void)hal_uart_sendChar(HAL_UART_CHANNEL_COM_PORT, hoursUnits);
-    (void)hal_uart_sendChar(HAL_UART_CHANNEL_COM_PORT, ':');
-    (void)hal_uart_sendChar(HAL_UART_CHANNEL_COM_PORT, minutesTens);
-    (void)hal_uart_sendChar(HAL_UART_CHANNEL_COM_PORT, minutesUnits);
-    (void)hal_uart_sendChar(HAL_UART_CHANNEL_COM_PORT, ':');
-    (void)hal_uart_sendChar(HAL_UART_CHANNEL_COM_PORT, secondsTens);
-    (void)hal_uart_sendChar(HAL_UART_CHANNEL_COM_PORT, secondsUnits);
-    (void)hal_uart_sendChar(HAL_UART_CHANNEL_COM_PORT, '\n');
+/*     (void)hal_uart_sendChar(HAL_UART_CHANNEL_COM_PORT, hoursTens); */
+/*     (void)hal_uart_sendChar(HAL_UART_CHANNEL_COM_PORT, hoursUnits); */
+/*     (void)hal_uart_sendChar(HAL_UART_CHANNEL_COM_PORT, ':'); */
+/*     (void)hal_uart_sendChar(HAL_UART_CHANNEL_COM_PORT, minutesTens); */
+/*     (void)hal_uart_sendChar(HAL_UART_CHANNEL_COM_PORT, minutesUnits); */
+/*     (void)hal_uart_sendChar(HAL_UART_CHANNEL_COM_PORT, ':'); */
+/*     (void)hal_uart_sendChar(HAL_UART_CHANNEL_COM_PORT, secondsTens); */
+/*     (void)hal_uart_sendChar(HAL_UART_CHANNEL_COM_PORT, secondsUnits); */
+/*     (void)hal_uart_sendChar(HAL_UART_CHANNEL_COM_PORT, '\n'); */
 
-    vTaskDelayUntil(&lastWakeTime, freq);
-  }
-}
+/*     (void)dev_console_processCommandString("Why hello there"); */
 
-void USART2_IRQHandler(void) {
-  char receivedChar;
-  hal_uart_receiveChar(HAL_UART_CHANNEL_COM_PORT, &receivedChar);
-  hal_uart_sendChar(HAL_UART_CHANNEL_COM_PORT, receivedChar);
-}
+/*     vTaskDelayUntil(&lastWakeTime, freq); */
+/*   } */
+/* } */
 
 int main(void) {
   (void)hal_init();
 
-  (void)hal_rtc_microSpecific_init();
+  /* (void)hal_rtc_microSpecific_init(); */
   (void)hal_gpio_microSpecific_init();
   (void)hal_uart_microSpecific_init();
 
   hal_rtc_time_S initialTime = {
-    .year = 0, // 2000
-    .month = 9, // September
-    .day = 14,
-    .weekday = 4,
-    .hour = 13, // 1PM (24H format)
-    .minute = 32,
-    .seconds = 54
+      .year = 0,  // 2000
+      .month = 9, // September
+      .day = 14,
+      .weekday = 4,
+      .hour = 13, // 1PM (24H format)
+      .minute = 32,
+      .seconds = 54
   };
 
   hal_rtc_setTime(&initialTime);
+
+  // Device layer init
+  (void)dev_console_microSpecific_init();
 
   // ENABLE USART2 Interrupt in the NVIC
   // Use lowest priority, might need to tinker with this later
   NVIC_SetPriority(USART2_IRQn, 0x03);
   NVIC_EnableIRQ(USART2_IRQn);
 
-  for (;;);
+  /* for (;;); */
 
   // These handles are used to identify the tasks and reference them.
   // Suspend, resume, notify etc.
   xTaskHandle blinkyTaskHandle;
-  xTaskHandle rtcTaskHandle;
+  /* xTaskHandle rtcTaskHandle; */
 
+  // Task names must be < 16
   xTaskCreate(blinky_task, "blinky", 50, NULL, tskIDLE_PRIORITY, &blinkyTaskHandle);
-  xTaskCreate(rtc_task, "rtc", 50, NULL, tskIDLE_PRIORITY + 1, &rtcTaskHandle);
+  /* xTaskCreate(rtc_task, "rtc", 50, NULL, tskIDLE_PRIORITY + 1, &rtcTaskHandle); */
 
   vTaskStartScheduler();
 

--- a/src/main.c
+++ b/src/main.c
@@ -1,6 +1,8 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "FreeRTOSConfig.h"
+#include "dev_alarm.h"
 #include "stm32l0xx.h"
 
 #include "system_stm32l0xx.h"
@@ -23,6 +25,7 @@
 
 #include "dev_console.h"
 #include "dev_console_microSpecific.h"
+#include "dev_alarm_microSpecific.h"
 
 #include "interrupts.h"
 
@@ -35,8 +38,8 @@
 // Task Handles
 // These handles are used to identify the tasks and reference them.
 // Suspend, resume, notify etc.
-xTaskHandle blinkyTaskHandle;
-xTaskHandle rtcTaskHandle;
+xTaskHandle slowTaskHandle;
+xTaskHandle fastTaskHandle;
 xTaskHandle consoleTaskHandle;
 
 extern volatile char receivedString[DEV_CONSOLE_MAX_COMMAND_LENGTH];
@@ -54,12 +57,13 @@ static void console_task(void *pvParameters) {
   }
 }
 
-static void blinky_task(void *pvParameters) {
+static void task_100ms(void *pvParameters) {
   TickType_t lastWakeTime = xTaskGetTickCount();
   // Blink the led at 10Hz
   const TickType_t freq = 100;
 
   for (;;) {
+    // Blinky
     hal_gpio_pinState_E currentPinState = hal_gpio_readInputState(HAL_GPIO_CHANNEL_LED);
     hal_gpio_pinState_E nextPinState;
     if (currentPinState == HAL_GPIO_PINSTATE_ON) {
@@ -69,13 +73,19 @@ static void blinky_task(void *pvParameters) {
     }
     hal_gpio_setOutputState(HAL_GPIO_CHANNEL_LED, nextPinState);
 
+    // Device layer state machines
+    dev_alarm_runLoop();
+
+    // App layer state machines
+
     vTaskDelayUntil(&lastWakeTime, freq);
   }
 }
 
-static void rtc_task(void *pvParameters) {
+static void task_10ms(void *pvParameters) {
   TickType_t lastWakeTime = xTaskGetTickCount();
-  const TickType_t freq = 1000;
+  // Blink the led at 100Hz
+  const TickType_t freq = 10;
 
   for (;;) {
     vTaskDelayUntil(&lastWakeTime, freq);
@@ -93,24 +103,26 @@ int main(void) {
       .year = 0,  // 2000
       .month = 9, // September
       .day = 14,
-      .weekday = 4,
-      .hour = 13, // 1PM (24H format)
-      .minute = 32,
-      .seconds = 54
+      .weekday = 4, // Thursday
+      .hour = 7, // 1PM (24H format)
+      .minute = 29,
+      .seconds = 30
   };
 
   hal_rtc_setTime(&initialTime);
 
   // Device layer init
   (void)dev_console_microSpecific_init();
+  dev_alarm_microSpecific_init();
 
   interrupts_init();
 
+  // Stack is max 128 words given FreeRTOS heap size of 4096
   // Task names must be < 16
-  xTaskCreate(blinky_task, "blinky", 50, NULL, tskIDLE_PRIORITY, &blinkyTaskHandle);
-  xTaskCreate(rtc_task, "rtc", 50, NULL, tskIDLE_PRIORITY + 1, &rtcTaskHandle);
+  xTaskCreate(task_100ms, "task_100ms", 32, NULL, tskIDLE_PRIORITY, &slowTaskHandle);
+  xTaskCreate(task_10ms, "task_10ms", 32, NULL, tskIDLE_PRIORITY, &fastTaskHandle);
   // Set console task as highest priority so nothing hangs
-  xTaskCreate(console_task, "console", 50, NULL, tskIDLE_PRIORITY + 2, &consoleTaskHandle);
+  xTaskCreate(console_task, "console", configMINIMAL_STACK_SIZE, NULL, tskIDLE_PRIORITY + 1, &consoleTaskHandle);
 
   vTaskStartScheduler();
 


### PR DESCRIPTION
- Create dev_console module to accept various commands.
- Create dev_alarm module. Layered on top of hal_rtc, it can poll for timestamps and set alarm flags.
- Connect dev_alarm to a console command which can print a timestamp and display an alarm channel's status.